### PR TITLE
Additional improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@ name: mechanical-markdown
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
   pull_request:
@@ -16,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHON_VER: 3.7
-      TWINE_USERNAME: ${{ secrets.PYPI_UPLOAD_USER }}
-      TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
+      TWINE_USERNAME: "__token__"
+      TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ env.PYTHON_VER }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mechanical Markdown
 
-[![codecov](https://codecov.io/gh/wcs1only/mechanical-markdown/branch/main/graph/badge.svg)](https://codecov.io/gh/wcs1only/mechanical-markdown)
+[![codecov](https://codecov.io/gh/dapr/mechanical-markdown/branch/main/graph/badge.svg)](https://codecov.io/gh/dapr/mechanical-markdown)
 
 If you are using markdown to create tutorials for your users, these markdown files will often be a series of shell commands that a user will copy and paste into their shell of choice, along with detailed text description of what each command is doing.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -154,6 +154,7 @@ expected_stdout_lines:
   - "Would run the following validation steps:"
   - "Step: Hello World"
   - "Step: CLI help"
+  - "Step: CLI version"
   - "Step: CLI dry run"
   - "Step: Pause for manual validation"
 -->

--- a/examples/io.md
+++ b/examples/io.md
@@ -1,5 +1,6 @@
 # I/O Validation
 
+## Using This Guide
 This is an example markdown file with an annotated test command.
 
 To see a summary of what commands will be run:
@@ -15,6 +16,8 @@ mm.py io.md
 ```
 
 Be sure to checkout the raw version of this file to see the annotations.
+
+## Checking stdout/stderr
 
 This is an annotated command. When the ```mm.py``` utility is run, the following code block will be executed:
 
@@ -49,6 +52,34 @@ echo "another_output_line"
 echo "test2"
 
 echo "error" 1>&2
+```
+
+<!-- END_STEP -->
+
+## Checking return code
+
+By default, all code blocks are expected to return 0. You can change this behavior with the directive ```expected_return_code```:
+
+<!-- STEP
+name: Non-zero Return Code
+expected_return_code: 1
+-->
+
+```bash
+exit 1
+```
+
+<!-- END_STEP -->
+
+A missing or null value for ```expected_return_code``` will ignore all return codes.
+
+<!-- STEP
+name: Ignore Return Code
+expected_return_code:
+-->
+
+```bash
+exit 15
 ```
 
 <!-- END_STEP -->

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.1.8'
+__version__ = '0.2.0'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/step.py
+++ b/mechanical_markdown/step.py
@@ -79,7 +79,7 @@ class Step:
         for command in self.commands:
             if self.background:
                 command.wait_or_timeout(self.timeout)
-                if command.return_code != self.expect_return_code:
+                if self.expect_return_code is not None and command.return_code != self.expect_return_code:
                     success = False
         return success
 

--- a/mechanical_markdown/step.py
+++ b/mechanical_markdown/step.py
@@ -29,6 +29,7 @@ class Step:
             self.expected_lines['stdout'] = parameters["expected_stdout_lines"]
         if "expected_stderr_lines" in parameters and parameters["expected_stderr_lines"] is not None:
             self.expected_lines['stderr'] = parameters["expected_stderr_lines"]
+        self.expect_return_code = 0 if "expected_return_code" not in parameters else parameters["expected_return_code"]
         self.working_dir = os.getcwd() if "working_dir" not in parameters else parameters["working_dir"]
         self.timeout = default_timeout_seconds if "timeout_seconds" not in parameters else parameters["timeout_seconds"]
         self.env = dict(os.environ, **parameters['env']) if "env" in parameters else os.environ
@@ -50,7 +51,7 @@ class Step:
             command.run(self.working_dir, self.env, shell)
             if not self.background:
                 command.wait_or_timeout(self.timeout)
-                if command.return_code != 0:
+                if self.expect_return_code is not None and command.return_code != self.expect_return_code:
                     return False
             if self.sleep:
                 time.sleep(self.sleep)
@@ -69,6 +70,8 @@ class Step:
             for expected in self.expected_lines[out]:
                 retstr += "\t\t{}\n".format(expected)
 
+        retstr += "\tExpected return code: {}\n".format(self.expect_return_code)
+
         return retstr + "\n"
 
     def wait_for_all_background_commands(self):
@@ -76,7 +79,7 @@ class Step:
         for command in self.commands:
             if self.background:
                 command.wait_or_timeout(self.timeout)
-                if command.return_code != 0:
+                if command.return_code != self.expect_return_code:
                     success = False
         return success
 
@@ -89,7 +92,9 @@ class Step:
         for c in self.commands:
             if c.process is not None:
                 color = 'green'
-                if c.return_code != 0:
+                if self.expect_return_code is None:
+                    color = 'yellow'
+                elif c.return_code != self.expect_return_code:
                     color = 'red'
                 report += "\tcommand: `{}`\n\treturn_code: {}\n".format(c.command, colored(c.return_code, color))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description="Run markdown recipes as shell scripts",
     long_description=README,
     long_description_content_type="text/markdown",
-    url="https://github.com/wcs1only/mechanical-markdown",
+    url="https://github.com/dapr/mechanical-markdown",
     author="Charlie Stanley",
     author_email="Charlie.Stanley@microsoft.com",
     license="MIT",


### PR DESCRIPTION
Add an ```expected_return_code``` directive. This allows you to have a command return non-zero, or to ignore return codes entirely.

Also in this PR: 
- Update the URL to point to dapr/mechanical-markdown as the primary repo.
- Integration with pypi to push this package automatically on a tag build.