### PR TITLE
Add --version option to cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine tox
+        pip install -rdev-requirements.txt
     - name: Run Linter
       run: |
         tox -e flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,10 @@
+mistune==0.8.4
+termcolor
+pyyaml
 setuptools
+twine
+tox
+wheel
 mypy>=0.761
 mypy-extensions>=0.4.3
 flake8>=3.7.9 

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,13 +83,6 @@ echo "A command that will not be run"
 
 Let's breakdown what this embedded yaml annotation is doing. There are two fields in our yaml document ```name``` and ```expected_stdout_lines```. The name field simply provides a name for the step that will be printed to the report that mm.py generates. The expected_stdout_lines field is actually telling mm.py what it should be looking for from stdout when it executes our code block(s). For more on this, checkout [io.md](io.md). 
 
-
-Code blocks must be tagged as either "bash" or "sh". Code from other languages will be ignored.
-
-
-<!-- END_STEP -->
-
-
 ## CLI
 
 ### Help
@@ -98,12 +91,13 @@ For a list of options:
 <!-- STEP 
 name: CLI help
 expected_stdout_lines:
-  - "usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] markdown_file"
+  - "usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] [--version]"
+  - "             [MARKDOWN_FILE]"
   - "Auto validate markdown documentation"
-  - "positional arguments:"
-  - "  markdown_file"
   - "optional arguments:"
   - "  -h, --help            show this help message and exit"
+  - "  --version, -v         Print version and exit"
+  - "  MARKDOWN_FILE         The annotated markdown file to run/execute"
   - "  --dry-run, -d         Print out the commands we would run based on"
   - "                        markdown_file"
   - "  --manual, -m          If your markdown_file contains manual validation"
@@ -119,20 +113,37 @@ mm.py --help
 <!-- END_STEP -->
 
 ```
-usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] markdown_file
+usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] [--version]
+             [MARKDOWN_FILE]
 
 Auto validate markdown documentation
 
-positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
+  --version, -v         Print version and exit
+
+  MARKDOWN_FILE         The annotated markdown file to run/execute
   --dry-run, -d         Print out the commands we would run based on
-			markdown_file
+                        markdown_file
   --manual, -m          If your markdown_file contains manual validation
-			steps, pause for user input
+                        steps, pause for user input
   --shell SHELL_CMD, -s SHELL_CMD
-			Specify a different shell to use
+                        Specify a different shell to use
 ```
+
+### Version
+
+<!-- STEP 
+name: CLI version
+expected_stderr_lines:
+  - "mm.py version:"
+-->
+
+```bash
+mm.py --version
+```
+
+<!-- END_STEP -->
 
 ### Dry Run
 You can do a dry run to print out exactly what commands will be run using the '-d' flag.

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ expected_stdout_lines:
   - "Auto validate markdown documentation"
   - "optional arguments:"
   - "  -h, --help            show this help message and exit"
-  - "  --version, -v         Print version and exit"
+  - "  --version             Print version and exit"
   - "  MARKDOWN_FILE         The annotated markdown file to run/execute"
   - "  --dry-run, -d         Print out the commands we would run based on"
   - "                        markdown_file"
@@ -120,7 +120,7 @@ Auto validate markdown documentation
 
 optional arguments:
   -h, --help            show this help message and exit
-  --version, -v         Print version and exit
+  --version             Print version and exit
 
   MARKDOWN_FILE         The annotated markdown file to run/execute
   --dry-run, -d         Print out the commands we would run based on

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -4,9 +4,9 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
-__version__ = '0.1.7'
-
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
+
+__version__ = '0.1.8'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -4,8 +4,9 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
+from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__all__ = [MechanicalMarkdown]
+__all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__main__.py
+++ b/mechanical_markdown/__main__.py
@@ -4,7 +4,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
-from mechanical_markdown import MechanicalMarkdown
+import mechanical_markdown
 
 import sys
 import argparse
@@ -12,23 +12,39 @@ import argparse
 
 def main():
     parse_args = argparse.ArgumentParser(description='Auto validate markdown documentation')
-    parse_args.add_argument('markdown_file', metavar='markdown_file', nargs=1, type=argparse.FileType('r'))
-    parse_args.add_argument('--dry-run', '-d',
-                            dest='dry_run',
+    group = parse_args.add_argument_group()
+    group.add_argument('markdown_file',
+                       metavar='MARKDOWN_FILE',
+                       nargs='?',
+                       type=argparse.FileType('r'),
+                       help="The annotated markdown file to run/execute")
+    group.add_argument('--dry-run', '-d',
+                       dest='dry_run',
+                       action='store_true',
+                       help='Print out the commands we would run based on markdown_file')
+    group.add_argument('--manual', '-m',
+                       dest='manual',
+                       action='store_true',
+                       help='If your markdown_file contains manual validation steps, pause for user input')
+    group.add_argument('--shell', '-s',
+                       dest='shell_cmd',
+                       default='bash -c',
+                       help='Specify a different shell to use')
+    parse_args.add_argument('--version',
+                            dest='print_version',
                             action='store_true',
-                            help='Print out the commands we would run based on markdown_file')
-    parse_args.add_argument('--manual', '-m',
-                            dest='manual',
-                            action='store_true',
-                            help='If your markdown_file contains manual validation steps, pause for user input')
-    parse_args.add_argument('--shell', '-s',
-                            dest='shell_cmd',
-                            default='bash -c',
-                            help='Specify a different shell to use')
+                            help='Print version and exit')
     args = parse_args.parse_args()
 
-    body = args.markdown_file[0].read()
-    r = MechanicalMarkdown(body)
+    if args.print_version:
+        parse_args.exit(status=0, message='{} version:\nv{}'.format(parse_args.prog, mechanical_markdown.__version__))
+
+    if args.markdown_file is None:
+        parse_args.error('You must provide exactly one markdown file to operate on.\n\
+                         Try "{} -h" for more info'.format(parse_args.prog))
+
+    body = args.markdown_file.read()
+    r = mechanical_markdown.MechanicalMarkdown(body)
     success = True
 
     if args.dry_run:

--- a/mechanical_markdown/parsers.py
+++ b/mechanical_markdown/parsers.py
@@ -14,6 +14,10 @@ start_token = 'STEP'
 end_token = 'END_STEP'
 
 
+class MarkdownAnnotationError(Exception):
+    pass
+
+
 class HTMLCommentParser(HTMLParser):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -41,7 +45,7 @@ class RecipeParser(Renderer):
         comment_body = comment_parser.comment_text
         if comment_body.find(end_token) >= 0:
             if self.current_step is None:
-                return ""
+                raise MarkdownAnnotationError("Unexpected <!-- {} --> found".format(end_token))
             self.all_steps.append(self.current_step)
             self.current_step = None
             return ""

--- a/mechanical_markdown/recipe.py
+++ b/mechanical_markdown/recipe.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 """
 
 from mistune import Markdown
-from mechanical_markdown.parsers import RecipeParser
+from mechanical_markdown.parsers import RecipeParser, end_token, MarkdownAnnotationError
 
 
 class Recipe:
@@ -13,6 +13,8 @@ class Recipe:
         parser = RecipeParser()
         md = Markdown(parser, extensions=('fenced-code',))
         md(markdown)
+        if parser.current_step is not None:
+            raise MarkdownAnnotationError('Reached end of input searching for <!-- {} -->'.format(end_token))
         self.all_steps = parser.all_steps
 
     def exectute_steps(self, manual, default_shell='bash -c'):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except FileNotFoundError:
 # This call to setup() does all the work
 setup(
     name="mechanical-markdown",
-    version="0.1.6",
+    version="0.1.7",
     description="Run markdown recipes as shell scripts",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 """
 
 from setuptools import setup, find_packages
+from mechanical_markdown import __version__ as version
 
 # The text of the README file
 README = ""
@@ -18,7 +19,7 @@ except FileNotFoundError:
 # This call to setup() does all the work
 setup(
     name="mechanical-markdown",
-    version="0.1.7",
+    version=version,
     description="Run markdown recipes as shell scripts",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_mechanical_markdown.py
+++ b/tests/test_mechanical_markdown.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import unittest
 
-from mechanical_markdown import MechanicalMarkdown
+from mechanical_markdown import MechanicalMarkdown, MarkdownAnnotationError
 from unittest.mock import patch, MagicMock, call
 
 
@@ -437,3 +437,34 @@ echo "test"
                                            stderr=subprocess.PIPE,
                                            universal_newlines=True,
                                            env=os.environ)
+
+    def test_missing_end_tag_throws_exception(self):
+        test_data = """
+<!-- STEP
+name: basic test
+-->
+
+```bash
+echo "test"
+```
+
+"""
+        with self.assertRaises(MarkdownAnnotationError):
+            MechanicalMarkdown(test_data)
+
+    def test_missing_extra_tag_throws_exception(self):
+        test_data = """
+<!-- STEP
+name: basic test
+-->
+
+```bash
+echo "test"
+```
+
+<!-- END_STEP -->
+
+<!-- END_STEP -->
+"""
+        with self.assertRaises(MarkdownAnnotationError):
+            MechanicalMarkdown(test_data)

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,6 @@ usedevelop = False
 deps = flake8
 commands =
     flake8 --config setup.cfg .
+commands_pre =
+    pip3 install -rdev-requirements.txt
 


### PR DESCRIPTION
There is now an ```mm.py --version```. Works as you'd expect. Also, raise a parser error for unclosed annotations.