### PR TITLE
Add optional link validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ print(ouput)
 
 # Run the commands in the order they were specified and return a boolean for succes or failure
 # Also returns a report summarizing what was run and stdout/sterr for each command
-success, report = exectute_steps(manual, default_shell='bash -c')
+success, report = exectute_steps(manual, default_shell='bash -c', validate_links=False)
 print(report)
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,11 +92,13 @@ For a list of options:
 name: CLI help
 expected_stdout_lines:
   - "usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] [--version]"
+  - "             [--validate-links]"
   - "             [MARKDOWN_FILE]"
   - "Auto validate markdown documentation"
   - "optional arguments:"
   - "  -h, --help            show this help message and exit"
   - "  --version             Print version and exit"
+  - "  --validate-links, -l  Check for broken links to external URLs"
   - "  MARKDOWN_FILE         The annotated markdown file to run/execute"
   - "  --dry-run, -d         Print out the commands we would run based on"
   - "                        markdown_file"
@@ -114,6 +116,7 @@ mm.py --help
 
 ```
 usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] [--version]
+             [--validate-links]
              [MARKDOWN_FILE]
 
 Auto validate markdown documentation
@@ -121,6 +124,7 @@ Auto validate markdown documentation
 optional arguments:
   -h, --help            show this help message and exit
   --version             Print version and exit
+  --validate-links, -l  Check for broken links to external URLs
 
   MARKDOWN_FILE         The annotated markdown file to run/execute
   --dry-run, -d         Print out the commands we would run based on
@@ -236,8 +240,25 @@ manual_pause_message: "Waiting for user input"
 mm.py -m README.md 
 ```
 
+### Link validation
+
+Mechanical markdown can optionally check your document for broken external links. It does so by simply making a GET request to any link it finds so long as that link begins with ```http(s)://```. Relative links are not currently supported. Any 2XX or 3XX status code response will be treated as success. Any 4XX or 5XX response will be treated as an error.
+
+```bash
+mm.py -l README.md
+```
+
+This will append to the report a footer to the runtime report:
+```
+External link validation:
+        https://github.com/dapr/quickstarts Status: 200
+        https://dapr.io/ Status: 200
+```
+
 # More examples:
 
 - For more details on checking stdout/stderr: [I/O Validation](io.md)
 - For more details on setting up the execution environment: [Environment Variables](env.md) and [Working Directory](working_dir.md)
 - For controlling timeouts, backgrounding, and adding delay between steps: [Sleeping, Timeouts, and Backgrounding](background.md)
+
+This tool was written to support the [Dapr Quickstarts](https://github.com/dapr/quickstarts). Be sure to check out [Dapr](https://dapr.io/)!

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__main__.py
+++ b/mechanical_markdown/__main__.py
@@ -34,6 +34,11 @@ def main():
                             dest='print_version',
                             action='store_true',
                             help='Print version and exit')
+    parse_args.add_argument('--validate-links', '-l',
+                            dest='validate_links',
+                            default=False,
+                            action='store_true',
+                            help='Check for broken links to external URLs')
     args = parse_args.parse_args()
 
     if args.print_version:
@@ -52,7 +57,7 @@ def main():
         print(r.dryrun(args.shell_cmd))
         sys.exit(0)
 
-    success, report = r.exectute_steps(args.manual, args.shell_cmd)
+    success, report = r.exectute_steps(args.manual, args.shell_cmd, validate_links=args.validate_links)
     print(report)
     if not success:
         sys.exit(1)

--- a/mechanical_markdown/parsers.py
+++ b/mechanical_markdown/parsers.py
@@ -4,6 +4,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
+import re
 import yaml
 
 from html.parser import HTMLParser
@@ -32,6 +33,7 @@ class RecipeParser(Renderer):
         super().__init__(**kwargs)
         self.current_step = None
         self.all_steps = []
+        self.external_links = []
 
     def block_code(self, text, lang):
         if lang is not None and lang.strip() in ('bash', 'sh') and self.current_step is not None:
@@ -59,3 +61,7 @@ class RecipeParser(Renderer):
         self.current_step = Step(yaml.safe_load(comment_body[start_pos:]))
 
         return ""
+
+    def link(self, link, text=None, title=None):
+        if re.match("https?://", link) is not None:
+            self.external_links.append(link)

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,11 @@ commands_pre =
 [testenv:examples]
 changedir=./examples/
 commands = 
-    mm.py README.md
-    mm.py io.md
-    mm.py background.md
-    mm.py env.md
-    mm.py working_dir.md
+    mm.py -l README.md
+    mm.py -l io.md
+    mm.py -l background.md
+    mm.py -l env.md
+    mm.py -l working_dir.md
 
 
 [testenv:flake8]


### PR DESCRIPTION
The CLI utility now has a flag to validate any links included in a markdown document. It will parse the document for URLs, and make a GET request for every one that it finds. Any 2XX or 3XX status code passes validation, and any 4XX or 5XX status code fails validation. Connection failures also fail validation.

close: #5