### PR TITLE
Add an annotation to allow particular links to be skipped during link validation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -244,6 +244,18 @@ mm.py -m README.md
 
 Mechanical markdown can optionally check your document for broken external links. It does so by simply making a GET request to any link it finds so long as that link begins with ```http(s)://```. Relative links are not currently supported. Any 2XX or 3XX status code response will be treated as success. Any 4XX or 5XX response will be treated as an error.
 
+If you need a particular link to be ignored while link checking, you can do so by enclosing it within the following annotations:
+
+<!-- IGNORE_LINKS -->
+
+    <!-- IGNORE_LINKS -->
+
+This link should be ignored: [Ignore](https://0.0.0.0/a_bad_link)
+
+    <!-- END_IGNORE -->
+
+<!-- END_IGNORE -->
+
 ```bash
 mm.py -l README.md
 ```
@@ -251,6 +263,7 @@ mm.py -l README.md
 This will append to the report a footer to the runtime report:
 ```
 External link validation:
+        https://0.0.0.0/a_bad_link Status: Ignored
         https://github.com/dapr/quickstarts Status: 200
         https://dapr.io/ Status: 200
 ```

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.2.3'
+__version__ = '0.2.4'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]


### PR DESCRIPTION
Now that we're doing link validation, we might actually have cause to disable it for particular links that we know won't pass validation (like http://localhost:8080).