### PR TITLE
Throw exception for duplicate STEP or IGNORE_LINKS annotations

### DIFF
--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/parsers.py
+++ b/mechanical_markdown/parsers.py
@@ -57,6 +57,8 @@ class RecipeParser(Renderer):
             return ""
 
         elif comment_body.find(ignore_links_token) >= 0:
+            if self.ignore_links:
+                raise MarkdownAnnotationError(f"Duplicate <!-- {ignore_links_token} --> found")
             self.ignore_links = True
 
         elif comment_body.find(end_ignore_links_token) >= 0:
@@ -68,6 +70,9 @@ class RecipeParser(Renderer):
 
         if start_pos < 0:
             return ""
+
+        if self.current_step is not None:
+            raise MarkdownAnnotationError(f"<!-- {start_token} --> found while still processing previous step")
 
         start_pos += len(start_token)
         self.current_step = Step(yaml.safe_load(comment_body[start_pos:]))

--- a/tests/test_mechanical_markdown.py
+++ b/tests/test_mechanical_markdown.py
@@ -462,6 +462,41 @@ echo "test"
         with self.assertRaises(MarkdownAnnotationError):
             MechanicalMarkdown(test_data)
 
+    def test_missmatched_start_and_end_tags_throws_exception(self):
+        test_data = """
+<!-- STEP
+name: basic test
+-->
+
+```bash
+echo "test"
+```
+
+<!-- STEP
+name: another basic test
+-->
+
+```bash
+echo "another test"
+```
+
+<!-- END_STEP -->
+
+"""
+        with self.assertRaises(MarkdownAnnotationError):
+            MechanicalMarkdown(test_data)
+
+        test_data = """
+<!-- IGNORE_LINKS -->
+
+<!-- IGNORE_LINKS -->
+
+<!-- END_IGNORE -->
+
+"""
+        with self.assertRaises(MarkdownAnnotationError):
+            MechanicalMarkdown(test_data)
+
     def test_missing_extra_tag_throws_exception(self):
         test_data = """
 <!-- STEP


### PR DESCRIPTION
Throw an error when ```<!-- END_STEP -->``` or ```<!-- END_IGNORE -->``` annotations are missing.

closes: #8