### PR TITLE
Support windows shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ Creating a MechanicalMarkdown instance from a string which contains a markdown d
 ```python
 from mechanical_markdown import MechanicalMarkdown
 
-mm = MechanicalMarkdown(markdown_string)
+mm = MechanicalMarkdown(markdown_string, shell="bash -c")
 ```
 
 MechanicalMarkdown methods 
 
 ```python
 # Returns a string describing the commands that would be run
-output = mm.dryrun(default_shell='bash -c')
+output = mm.dryrun()
 print(ouput)
 
 # Run the commands in the order they were specified and return a boolean for succes or failure
 # Also returns a report summarizing what was run and stdout/sterr for each command
-success, report = exectute_steps(manual, default_shell='bash -c', validate_links=False, link_retries=3)
+success, report = exectute_steps(manual, validate_links=False, link_retries=3)
 print(report)
 
 

--- a/examples/io.md
+++ b/examples/io.md
@@ -56,6 +56,38 @@ echo "error" 1>&2
 
 <!-- END_STEP -->
 
+## Match mode
+
+You can specify the output matching strategy with the `output_match_mode` directive. 
+
+There are two supported line validation types `exact` and `substring`. These do as their names suggest, with `exact` requiring the entire line of output to match, and `substring` requires only part of the line to match. The default is `exact`.
+
+<!-- STEP
+name: Exact match
+output_match_mode: exact
+expected_stdout_lines:
+  - "Match this entire line"
+-->
+
+```bash
+echo "Match this entire line"
+```
+
+<!-- END_STEP -->
+
+<!-- STEP
+name: Partial match
+output_match_mode: substring
+expected_stdout_lines:
+  - "partial string"
+-->
+
+```bash
+echo "Match partial string"
+```
+
+<!-- END_STEP -->
+
 ## Checking return code
 
 By default, all code blocks are expected to return 0. You can change this behavior with the directive ```expected_return_code```:

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__main__.py
+++ b/mechanical_markdown/__main__.py
@@ -6,8 +6,9 @@ Licensed under the MIT License.
 
 import mechanical_markdown
 
-import sys
 import argparse
+import colorama
+import sys
 
 
 def main():
@@ -55,16 +56,19 @@ def main():
                          Try "{} -h" for more info'.format(parse_args.prog))
 
     body = args.markdown_file.read()
-    r = mechanical_markdown.MechanicalMarkdown(body)
+
+    # Enable color terminal support on Windows
+    colorama.init()
+
+    r = mechanical_markdown.MechanicalMarkdown(body, shell=args.shell_cmd)
     success = True
 
     if args.dry_run:
         print("Would run the following validation steps:")
-        print(r.dryrun(args.shell_cmd))
+        print(r.dryrun())
         sys.exit(0)
 
     success, report = r.exectute_steps(args.manual,
-                                       args.shell_cmd,
                                        validate_links=args.validate_links,
                                        link_retries=args.link_retries)
     print(report)

--- a/mechanical_markdown/parsers.py
+++ b/mechanical_markdown/parsers.py
@@ -32,12 +32,13 @@ class HTMLCommentParser(HTMLParser):
 
 
 class RecipeParser(Renderer):
-    def __init__(self, **kwargs):
+    def __init__(self, shell, **kwargs):
         super().__init__(**kwargs)
         self.current_step = None
         self.all_steps = []
         self.external_links = []
         self.ignore_links = False
+        self.shell = shell
 
     def block_code(self, text, lang):
         if lang is not None and lang.strip() in ('bash', 'sh') and self.current_step is not None:
@@ -75,7 +76,7 @@ class RecipeParser(Renderer):
             raise MarkdownAnnotationError(f"<!-- {start_token} --> found while still processing previous step")
 
         start_pos += len(start_token)
-        self.current_step = Step(yaml.safe_load(comment_body[start_pos:]))
+        self.current_step = Step(yaml.safe_load(comment_body[start_pos:]), self.shell)
 
         return ""
 

--- a/mechanical_markdown/recipe.py
+++ b/mechanical_markdown/recipe.py
@@ -12,8 +12,8 @@ from time import sleep
 
 
 class Recipe:
-    def __init__(self, markdown):
-        parser = RecipeParser()
+    def __init__(self, markdown, shell='bash -c'):
+        parser = RecipeParser(shell)
         md = Markdown(parser, extensions=('fenced-code',))
         md(markdown)
         if parser.current_step is not None:
@@ -23,11 +23,11 @@ class Recipe:
         self.all_steps = parser.all_steps
         self.external_links = parser.external_links
 
-    def exectute_steps(self, manual, default_shell='bash -c', validate_links=False, link_retries=3):
+    def exectute_steps(self, manual, validate_links=False, link_retries=3):
         success = True
         report = ""
         for step in self.all_steps:
-            if not step.run_all_commands(manual, default_shell):
+            if not step.run_all_commands(manual):
                 success = False
                 break
 
@@ -67,9 +67,9 @@ class Recipe:
 
         return success, report
 
-    def dryrun(self, default_shell='bash -c'):
+    def dryrun(self):
         retstr = ""
         for step in self.all_steps:
-            retstr += step.dryrun(default_shell)
+            retstr += step.dryrun()
 
         return retstr

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     packages=find_packages(exclude='tests'),
     include_package_data=True,
-    install_requires=["termcolor", "pyyaml", "mistune", "requests"],
+    install_requires=["termcolor", "pyyaml", "mistune", "requests", "colorama"],
     entry_points={
         "console_scripts": [
             "mm.py = mechanical_markdown.__main__:main"


### PR DESCRIPTION
One of the biggest blockers to Windows support is that Windows output pipes are extremely small (think <1k). We were relying on the fact that popen() is asynchronous to support backgrounded commands. On Linux/MacOS the backgrounded command can execute all its steps and comfortably write to the pipe and then we can come by at the and and call communicate() to drain the pipe, read the output and set the return code. On Windows, the pipe was filling up before execution could complete, thus the process would block writing to stdout and never actually finish its execution because we don't call communicate() on a backgrounded process until we've finished all the other steps.

To work around this limitation, we need to call communicate() right away after the start of execution so it can drain stdout. Since communicate() is a blocking call, we have to call it in a thread. This refactor spawns a thread for each execution (whether backgrounded or not). We then join() the thread where we used to call communicate().

Also in this PR: 
- colorized output on Windows
- Substring matching support (needed because the Dapr cli does not write unicode characters on Windows).

closes: #13
closes: #14