### PR TITLE
Bump default timeout to 300s

### DIFF
--- a/examples/background.md
+++ b/examples/background.md
@@ -52,7 +52,7 @@ echo "Second step"
 
 ## Backgrounding
 
-Conversely, if you want to run a step in the background without waiting to move on to the next step. This is great for starting services or daemons that you will clean up later on in the procedure. All backgrounded steps will be waited for at the end of execution so that stdout and stderr and the return code can all be checked. If a processes hasn't finished it will be timed out after 60s by default. See Timeout section below for more info.
+Conversely, if you want to run a step in the background without waiting to move on to the next step. This is great for starting services or daemons that you will clean up later on in the procedure. All backgrounded steps will be waited for at the end of execution so that stdout and stderr and the return code can all be checked. If a processes hasn't finished it will be timed out after 300s by default. See Timeout section below for more info.
 
 In this first step, run a command that will take at least 5 seconds, but mm.py doesn't wait for it before executing the next step.
 
@@ -87,7 +87,7 @@ date
 
 ## Timeouts
 
-By default, all commands timeout after 60s. They will receive a SIGTERM, followed by a SIGKILL. Script that reach their timeout and are killed will cause validation to fail and mm.py will return non-zero. You can change the duration of the timeout for an individual step by setting ```timeout_seconds``` .
+By default, all commands timeout after 300s. They will receive a SIGTERM, followed by a SIGKILL. Script that reach their timeout and are killed will cause validation to fail and mm.py will return non-zero. You can change the duration of the timeout for an individual step by setting ```timeout_seconds``` .
 
 > **Note:** sleep time does not count towards timeout_seconds.
 

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/step.py
+++ b/mechanical_markdown/step.py
@@ -10,7 +10,7 @@ import time
 from mechanical_markdown.command import Command
 from termcolor import colored
 
-default_timeout_seconds = 60
+default_timeout_seconds = 300
 
 VALID_MATCH_MODES = ('exact', 'substring')
 

--- a/tests/test_mechanical_markdown.py
+++ b/tests/test_mechanical_markdown.py
@@ -11,6 +11,8 @@ import unittest
 from mechanical_markdown import MechanicalMarkdown, MarkdownAnnotationError
 from unittest.mock import patch, MagicMock, call
 
+DEFAULT_TIMEOUT = 300
+
 
 class MechanicalMarkdownTests(unittest.TestCase):
     def setUp(self):
@@ -161,7 +163,7 @@ echo "test"
                                            universal_newlines=True,
                                            env=os.environ)
 
-        self.process_mock.communicate.assert_called_with(timeout=60)
+        self.process_mock.communicate.assert_called_with(timeout=DEFAULT_TIMEOUT)
 
     def test_background_failure(self):
         test_data = """
@@ -188,7 +190,7 @@ echo "test"
                                            universal_newlines=True,
                                            env=os.environ)
 
-        self.process_mock.communicate.assert_called_with(timeout=60)
+        self.process_mock.communicate.assert_called_with(timeout=DEFAULT_TIMEOUT)
 
     def test_failure_halts_further_executions(self):
         test_data = """
@@ -283,7 +285,7 @@ echo "error" 1>&2
                       stderr=subprocess.PIPE,
                       universal_newlines=True,
                       env=os.environ),
-                 call().communicate(timeout=60)]
+                 call().communicate(timeout=DEFAULT_TIMEOUT)]
         self.popen_mock.assert_has_calls(calls)
 
     def test_expected_lines_succeed_when_matched_substr(self):
@@ -311,7 +313,7 @@ echo "Match a substring"
                       stderr=subprocess.PIPE,
                       universal_newlines=True,
                       env=os.environ),
-                 call().communicate(timeout=60)]
+                 call().communicate(timeout=DEFAULT_TIMEOUT)]
         self.popen_mock.assert_has_calls(calls)
 
     def test_exception_raised_for_invalid_match_mode(self):
@@ -427,7 +429,7 @@ echo "test"
 <!-- END_STEP -->
 """
 
-        def raise_timeout(timeout=60):
+        def raise_timeout(timeout=DEFAULT_TIMEOUT):
             raise subprocess.TimeoutExpired("foo", 60.0)
 
         self.process_mock.communicate.side_effect = raise_timeout
@@ -442,7 +444,7 @@ echo "test"
                                            env=os.environ)
         self.process_mock.terminate.assert_called()
         self.process_mock.kill.assert_called()
-        self.process_mock.communicate.assert_has_calls([call(timeout=60), call(timeout=60)])
+        self.process_mock.communicate.assert_has_calls([call(timeout=DEFAULT_TIMEOUT), call(timeout=DEFAULT_TIMEOUT)])
 
     @patch("builtins.input")
     def test_pause_waits_for_user_input(self, input_mock):
@@ -611,7 +613,7 @@ exit 15
                       stderr=subprocess.PIPE,
                       universal_newlines=True,
                       env=os.environ),
-                 call().communicate(timeout=60),
+                 call().communicate(timeout=DEFAULT_TIMEOUT),
                  call(['bash', '-c', 'exit 15'],
                       stdout=subprocess.PIPE,
                       stderr=subprocess.PIPE,


### PR DESCRIPTION
Now that backgrounding is threaded, timeout values are measured from the start of process execution, not from the point at which wait() was called. In light of this, the 60s default timeout value was way too short. Bumping to 5 minutes.