### PR TITLE
Only call colorama.init() on Windows

### DIFF
--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__main__.py
+++ b/mechanical_markdown/__main__.py
@@ -8,6 +8,7 @@ import mechanical_markdown
 
 import argparse
 import colorama
+import platform
 import sys
 
 
@@ -58,7 +59,9 @@ def main():
     body = args.markdown_file.read()
 
     # Enable color terminal support on Windows
-    colorama.init()
+    # The colorama.init() call is supposed to be a no-op on Linux, but calling it breaks color output on github actions
+    if platform.system() == 'Windows':
+        colorama.init()
 
     r = mechanical_markdown.MechanicalMarkdown(body, shell=args.shell_cmd)
     success = True


### PR DESCRIPTION
For some reason, calling colorama.init() breaks colorized output for github actions. Since we only need it for Windows colorized output, we can just check to see if we're running on Windows before calling it.

closes: #20