### PR TITLE
Add ability to filter by step tags

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ For a list of options:
 name: CLI help
 expected_stdout_lines:
   - "usage: mm.py [-h] [--dry-run] [--manual] [--shell SHELL_CMD] [--version]"
-  - "             [--validate-links] [--link-retries RETRIES]"
+  - "             [--validate-links] [--link-retries RETRIES] [--tags TAGS]"
   - "             [MARKDOWN_FILE]"
   - "Auto validate markdown documentation"
   - "optional arguments:"

--- a/examples/README.md
+++ b/examples/README.md
@@ -102,6 +102,8 @@ expected_stdout_lines:
   - "  --link-retries RETRIES, -r RETRIES"
   - "                        Number of times to retry broken links [Default: 3]."
   - "                        Does nothing without -l"
+  - "  --tags TAGS, -t TAGS  Tags used to filter steps"
+
   - "  MARKDOWN_FILE         The annotated markdown file to run/execute"
   - "  --dry-run, -d         Print out the commands we would run based on"
   - "                        markdown_file"
@@ -129,9 +131,10 @@ optional arguments:
   --version             Print version and exit
   --validate-links, -l  Check for broken links to external URLs
   --link-retries RETRIES, -r RETRIES
-                        Number of times to retry broken links [Default: 3]."
-                        Does nothing without -l"
-
+                        Number of times to retry broken links [Default: 3].
+                        Does nothing without -l
+  --tags TAGS, -t TAGS  Tags used to filter steps
+  
   MARKDOWN_FILE         The annotated markdown file to run/execute
   --dry-run, -d         Print out the commands we would run based on
                         markdown_file
@@ -220,6 +223,15 @@ Step: Hello World
 If anything unexpected happens, you will get report
 of what went wrong, and mm.py will return non-zero.
 
+### Tags
+
+You can use the `--tags` argument to run only steps marked with the given tags. You may specify multiple tags and any steps that match one or more tags will be run. See [Tagging](tagging.md)
+
+```bash
+mm.py -t tag1 -t tag2 README.md
+```
+
+
 ### Shells
 
 The default shell used to execute scripts is ```bash -c```. You can use a different shell interpreter by specifying one via the cli:
@@ -285,5 +297,6 @@ mm.py -l -r 10 README.md
 - For more details on checking stdout/stderr: [I/O Validation](io.md)
 - For more details on setting up the execution environment: [Environment Variables](env.md) and [Working Directory](working_dir.md)
 - For controlling timeouts, backgrounding, and adding delay between steps: [Sleeping, Timeouts, and Backgrounding](background.md)
+- For tagging and executing a subset of steps: [Tagging](tagging.md)
 
 This tool was written to support the [Dapr Quickstarts](https://github.com/dapr/quickstarts). Be sure to check out [Dapr](https://dapr.io/)!

--- a/examples/tagging.md
+++ b/examples/tagging.md
@@ -1,0 +1,79 @@
+# I/O Validation
+
+## Using This Guide
+This is an example markdown file with an annotated test command.
+
+To see a summary of what commands will be run:
+
+```bash
+mm.py -d tagging.md
+```
+
+To run this file and validate the expected output:
+
+```bash
+mm.py tagging.md
+```
+
+Be sure to checkout the raw version of this file to see the annotations.
+
+## Tagging steps
+
+Sometimes your documentation may contain steps that are only meant to be run on a particular platform, or in a particular circumstance. You can use the `tags` directive to specify a list of tags with each step.
+
+<!-- STEP
+name: Linux Step
+expected_stdout_lines:
+  - Linux
+tags:
+  - linux
+-->
+
+This step is tagged `linux`. If you run `mm.py -t linux`, this step will be executed.
+
+```bash
+echo "Linux"
+```
+
+<!-- END_STEP -->
+
+This step is tagged `windows`. If you run `mm.py -t windows`, this step will be executed.
+
+<!-- STEP
+name: Windows Step
+expected_stdout_lines:
+  - Windows
+tags:
+  - windows
+-->
+
+```bash
+cmd.exe /C "echo Windows"
+```
+
+<!-- END_STEP -->
+
+This step is tagged with both `windows` and `linux`. If you run `mm.py -t windows` or `mm.py -t linux`, this step will be executed.
+
+<!-- STEP
+name: Windows Step
+expected_stdout_lines:
+  - Windows and Linux
+tags:
+  - windows
+  - linux
+-->
+
+```bash
+echo Windows and Linux
+```
+
+<!-- END_STEP -->
+
+**Note:** If you run `mm.py` without any tags, all steps are run, tagged or not.
+
+# Navigation
+
+* Back to [Sleeping, Timeouts, and Backgrounding](background.md)
+
+

--- a/mechanical_markdown/__init__.py
+++ b/mechanical_markdown/__init__.py
@@ -7,6 +7,6 @@ Licensed under the MIT License.
 from mechanical_markdown.recipe import Recipe as MechanicalMarkdown
 from mechanical_markdown.parsers import MarkdownAnnotationError
 
-__version__ = '0.4.2'
+__version__ = '0.5.0'
 
 __all__ = [MechanicalMarkdown, MarkdownAnnotationError]

--- a/mechanical_markdown/__main__.py
+++ b/mechanical_markdown/__main__.py
@@ -47,6 +47,12 @@ def main():
                             metavar='RETRIES',
                             type=int,
                             help='Number of times to retry broken links [Default: 3]. Does nothing without -l')
+    parse_args.add_argument('--tags', '-t',
+                            dest='tags',
+                            default=[],
+                            action="append",
+                            type=str,
+                            help='Tags used to filter steps')
     args = parse_args.parse_args()
 
     if args.print_version:
@@ -73,7 +79,8 @@ def main():
 
     success, report = r.exectute_steps(args.manual,
                                        validate_links=args.validate_links,
-                                       link_retries=args.link_retries)
+                                       link_retries=args.link_retries,
+                                       tags=args.tags)
     print(report)
     if not success:
         sys.exit(1)

--- a/mechanical_markdown/recipe.py
+++ b/mechanical_markdown/recipe.py
@@ -23,15 +23,16 @@ class Recipe:
         self.all_steps = parser.all_steps
         self.external_links = parser.external_links
 
-    def exectute_steps(self, manual, validate_links=False, link_retries=3):
+    def exectute_steps(self, manual, validate_links=False, link_retries=3, tags=[]):
         success = True
         report = ""
-        for step in self.all_steps:
+        stepsToRun = list(filter(lambda step: self.filter_steps(tags, step), self.all_steps))
+        for step in stepsToRun:
             if not step.run_all_commands(manual):
                 success = False
                 break
 
-        for step in self.all_steps:
+        for step in stepsToRun:
             if not step.wait_for_all_background_commands():
                 success = False
 
@@ -73,3 +74,13 @@ class Recipe:
             retstr += step.dryrun()
 
         return retstr
+
+    def filter_steps(self, tags, step):
+        if len(tags) == 0 or len(step.tags) == 0:
+            return True
+
+        for tag in tags:
+            if tag in step.tags:
+                return True
+
+        return False

--- a/mechanical_markdown/step.py
+++ b/mechanical_markdown/step.py
@@ -37,6 +37,7 @@ class Step:
         self.env = dict(os.environ, **parameters['env']) if "env" in parameters else os.environ
         self.pause_message = None if "manual_pause_message" not in parameters else parameters["manual_pause_message"]
         self.match_mode = 'exact' if "output_match_mode" not in parameters else parameters["output_match_mode"]
+        self.tags = [] if "tags" not in parameters else parameters["tags"]
         self.shell = shell
 
         if self.match_mode not in VALID_MATCH_MODES:

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
     mm.py -l background.md
     mm.py -l env.md
     mm.py -l working_dir.md
+    mm.py -t linux -l tagging.md 
 
 
 [testenv:flake8]


### PR DESCRIPTION
As more automations are added, certain README files may have steps
that only apply to specific scenarios. This change adds the ability
to specify tags and then only run steps that match those tags.

closes: #21