### PR TITLE
Update RecipeParser's link method to use updated parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 
 .coverage
 coverage.xml
+
+__pycache__/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-mistune~=2.0.0
+mistune>=3.0.0
 termcolor
 pyyaml
 setuptools

--- a/mechanical_markdown/parsers.py
+++ b/mechanical_markdown/parsers.py
@@ -81,8 +81,8 @@ class RecipeParser(HTMLRenderer):
 
         return ""
 
-    def link(self, link, text=None, title=None):
-        if re.match("https?://", link) is not None:
-            self.external_links.append((link, self.ignore_links))
+    def link(self, text, url=None, title=None):
+        if re.match("https?://", url) is not None:
+            self.external_links.append((url, self.ignore_links))
 
         return ""

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     packages=find_packages(exclude='tests'),
     include_package_data=True,
-    install_requires=["termcolor", "pyyaml", "mistune==2.0.5", "requests", "colorama"],
+    install_requires=["termcolor", "pyyaml", "mistune", "requests", "colorama"],
     entry_points={
         "console_scripts": [
             "mm.py = mechanical_markdown.__main__:main"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     packages=find_packages(exclude='tests'),
     include_package_data=True,
-    install_requires=["termcolor", "pyyaml", "mistune", "requests", "colorama"],
+    install_requires=["termcolor", "pyyaml", "mistune>=3.0.0", "requests", "colorama"],
     entry_points={
         "console_scripts": [
             "mm.py = mechanical_markdown.__main__:main"


### PR DESCRIPTION
The `link` method's signature was updated in this commit, causing mechanical markdown failures after the recent mistune releases.


https://github.com/lepture/mistune/commit/a382001d797c0244d7389d94045f31516ec384e9

<img width="520" alt="image" src="https://github.com/dapr/mechanical-markdown/assets/22132944/97ee4db6-002d-47fc-a30b-6c084cc35da3">

This PR was raised to pin mistune to an older version https://github.com/dapr/docs/pull/3521/files which turned out to be a temporary fix.

In this PR, the signature is updated and it does not error out anymore.

### From main branch
<img width="1669" alt="image" src="https://github.com/dapr/mechanical-markdown/assets/22132944/9b4aceb2-d4d2-4dfe-a753-a44839ca56aa">

### From fix branch
<img width="1498" alt="image" src="https://github.com/dapr/mechanical-markdown/assets/22132944/2f91e9b3-324d-404c-bf5f-71f7d09005cd">